### PR TITLE
Fix critically important link in the index

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -15,7 +15,7 @@ Contribute
 ----------
 
 - Issue Tracker: github.com/joscomputing/api.zenlikes.men/issues
-- Source Code: github.com/joscomputing/api.zenlikes.men/issues
+- Source Code: github.com/joscomputing/api.zenlikes.men
 
 Support
 -------


### PR DESCRIPTION
The link for source code directed the user to the issue page. This is unacceptable and can cause confusion leading to disbeliefs about how much Zen likes men.
As well as this, you can also make these links actually be links if you wanted to.